### PR TITLE
chore: bump Vitest version to v3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export class AwsCdkApp extends awscdk.AwsCdkTypeScriptApp {
         });
 
         if (vitest ?? true) {
-            const vitestVersion = "^2";
+            const vitestVersion = "^3";
             this.addDevDeps("@nikovirtala/projen-vitest", `vitest@${vitestVersion}`);
             new Vitest(this, { vitestVersion, ...vitestOptions });
         }


### PR DESCRIPTION
Vitest [v3.0.0](https://github.com/vitest-dev/vitest/releases/tag/v3.0.0) was just released a few days ago.